### PR TITLE
Add more tests for pe

### DIFF
--- a/tests/test_pe/test_pe.py
+++ b/tests/test_pe/test_pe.py
@@ -1,19 +1,49 @@
+import pytest
 import subprocess
-from pe import abs, and_
+import pe
 from testvectors import complete
 from verilator import compile, run_verilator_test
 
-def test_abs():
-    a = abs()
+ops  = ['or_', 'and_', 'xor']
+# ops += ['inv']
+ops += ['lshr', 'lshl']
+# ops += ['ashr']
+ops += ['add', 'sub']
+ops += ['abs']
+ops += ['eq']
+ops += ['sel']
+
+signed_ops = ['min', 'max', 'le', 'ge']
+def pytest_generate_tests(metafunc):
+    if 'op' in metafunc.fixturenames:
+        metafunc.parametrize("op", ops)
+    if 'signed_op' in metafunc.fixturenames:
+        metafunc.parametrize("signed_op", signed_ops)
+        metafunc.parametrize("signed", [True, False])
+    if 'const_value' in metafunc.fixturenames:
+        metafunc.parametrize("const_value", range(16))
+
+def test_op(op):
+    a = getattr(pe, op)()
 
     tests = complete(a, 4, 16)
 
-    compile('test_abs_complete', 'test_pe_comp_unq1', a.opcode, tests)
-    run_verilator_test('test_pe_comp_unq1', 'sim_test_abs_complete', 'test_pe_comp_unq1')
+    compile(f'test_{op}_complete', 'test_pe_comp_unq1', a.opcode, tests)
+    run_verilator_test('test_pe_comp_unq1', f'sim_test_{op}_complete', 'test_pe_comp_unq1')
 
-def test_and():
-    a = and_()
+def test_signed_op(signed_op, signed):
+    a = getattr(pe, signed_op)(signed)
 
     tests = complete(a, 4, 16)
-    compile('test_and_complete', 'test_pe_comp_unq1', a.opcode, tests)
-    run_verilator_test('test_pe_comp_unq1', 'sim_test_and_complete', 'test_pe_comp_unq1')
+
+    compile(f'test_{signed_op}_complete', 'test_pe_comp_unq1', a.opcode, tests)
+    run_verilator_test('test_pe_comp_unq1', f'sim_test_{signed_op}_complete', 'test_pe_comp_unq1')
+
+@pytest.mark.skip
+def test_const(const_value):
+    a = pe.const(const_value)
+
+    tests = complete(a, 4, 16)
+
+    compile(f'test_const_complete', 'test_pe_comp_unq1', a.opcode, tests)
+    run_verilator_test('test_pe_comp_unq1', f'sim_test_const_complete', 'test_pe_comp_unq1')


### PR DESCRIPTION
This turns on more unit tests for the pe.

`op = 'eq'` fails with the following test
```
test_iter=0, op_a=0, op_b=0, op_d_p=0, expected_res=0, actual_res=0
test_iter=1, op_a=0, op_b=1, op_d_p=0, expected_res=1, actual_res=1
test_iter=2, op_a=0, op_b=2, op_d_p=0, expected_res=2, actual_res=2
test_iter=3, op_a=0, op_b=3, op_d_p=0, expected_res=3, actual_res=3
test_iter=4, op_a=1, op_b=0, op_d_p=0, expected_res=1, actual_res=0
```
I suspect this is related to the comment found in `utest.py` that says 
```
# Spec says 'eq' result is same as 'add'
# GOLD['eq']    = GOLD['add']
# FIXME But verilog is different than spec!
```
What should the expected output for eq be? The verilog sets it to be `b`, the spec (what is the spec?? artem's document says a+b).

`op = 'sel'` fails with the following test
```
test_iter=0, op_a=0, op_b=0, op_d_p=0, expected_res=0, actual_res=0
test_iter=1, op_a=0, op_b=1, op_d_p=0, expected_res=0, actual_res=1
```

I see that `sel` is also mentioned twice in utest.py
```
  'sel' - no test yet b/c needs 'd' input
```

and

```
    # 'sel', # FIXME needs one-bit working
```