### PR TITLE
ncsim unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   - conda info -a
 
   # Install python dependencies
-  - pip install pytest numpy
+  - pip install pytest numpy delegator.py
   - pip install git+git://github.com/leonardt/pe.git
 
   # Run python based tests

--- a/tests/test_pe/ncsim.py
+++ b/tests/test_pe/ncsim.py
@@ -1,0 +1,34 @@
+def compile(name, opcode, tests):
+    test_string = ""
+
+    for test in tests:
+        test_string += f"  op_a = {test[0]};\n"
+        test_string += f"  op_b = {test[1]};\n"
+        test_string += f"  assert (res  == {test[2]}) else $error(\"Failed!\");\n"
+
+    harness = """\
+`timescale 1ns/1ns
+module tb;
+localparam WIDTH = 16;
+wire [WIDTH-1:0] op_a;
+wire [WIDTH-1:0] op_b;
+wire [WIDTH-1:0] op_c;
+wire [WIDTH-1:0] res;
+
+initial begin
+{tests}
+  #1000 $stop;
+end
+
+
+test_pe_comp_unq1 dut (
+    .op_a(op_a),
+    .op_b(op_b),
+    .op_c(op_c),
+    .res(res)
+    .op_code({opcode});
+   );
+endmodule
+""".format(tests=test_string,opcode=opcode&0x1ff)
+    with open('build/ncsim_'+name+'_tb.v', "w") as f:
+        f.write(harness)

--- a/tests/test_pe/ncsim.py
+++ b/tests/test_pe/ncsim.py
@@ -4,29 +4,29 @@ def compile(name, opcode, tests):
     for test in tests:
         test_string += f"  op_a = {test[0]};\n"
         test_string += f"  op_b = {test[1]};\n"
-        test_string += f"  assert (res  == {test[2]}) else $error(\"Failed!\");\n"
+        test_string += f"  #1\n"
+        test_string += f"  if (res != {test[2]}) $display(\"Failed!\");\n"
+        test_string += f"  #20\n"
 
     harness = """\
 `timescale 1ns/1ns
-module tb;
+module test_pe_comp_unq1_tb;
 localparam WIDTH = 16;
-wire [WIDTH-1:0] op_a;
-wire [WIDTH-1:0] op_b;
-wire [WIDTH-1:0] op_c;
+reg [WIDTH-1:0] op_a;
+reg [WIDTH-1:0] op_b;
 wire [WIDTH-1:0] res;
 
 initial begin
 {tests}
-  #1000 $stop;
+  #20 $finish;
 end
 
 
 test_pe_comp_unq1 dut (
     .op_a(op_a),
     .op_b(op_b),
-    .op_c(op_c),
-    .res(res)
-    .op_code({opcode});
+    .res(res),
+    .op_code({opcode})
    );
 endmodule
 """.format(tests=test_string,opcode=opcode&0x1ff)

--- a/tests/test_pe/test_pe.py
+++ b/tests/test_pe/test_pe.py
@@ -3,6 +3,7 @@ from testvectors import complete
 from verilator import compile, run_verilator_test
 import ncsim
 import delegator
+import os
 
 def test_abs():
     a = abs()
@@ -11,13 +12,18 @@ def test_abs():
 
     compile('test_abs_complete', 'test_pe_comp_unq1', a.opcode, tests)
     run_verilator_test('test_pe_comp_unq1', 'sim_test_abs_complete', 'test_pe_comp_unq1')
-    print("== Compiling ncsim test bench ==")
+    if os.environ.get("TRAVIS", True):
+        # Skip on Travis because cadence tools not available
+        # FIXME: Should check for cadence tools available instead
+        return
     ncsim.compile('test_abs_complete', a.opcode, tests)
     RTL_FOLDER = "../../hardware/generator_z/top/genesis_verif"
+    # irun -top tb -timescale 1ns/1ps -l irun.log -access +rwc -notimingchecks -input cmd.tcl build/ncsim_test_abs_complete_tb.v /nobackup/nikhil3/arm_mems/arm/tsmc/cln40g/sram_sp_hsc_rvt_hvt_rvt/r10p2/sram_512w_16b/sram_512w_16b.v {RTL_FOLDER}/cb_unq1.v {RTL_FOLDER}/cb_unq2.v {RTL_FOLDER}/cb_unq3.v {RTL_FOLDER}/global_controller_unq1.v {RTL_FOLDER}/global_signal_tile_unq1.v {RTL_FOLDER}/io1bit_unq1.v {RTL_FOLDER}/io1bit_unq2.v {RTL_FOLDER}/io1bit_unq3.v {RTL_FOLDER}/io1bit_unq4.v {RTL_FOLDER}/jtag_unq1.sv {RTL_FOLDER}/memory_core_unq1.v {RTL_FOLDER}/memory_tile_unq1.v {RTL_FOLDER}/mem_unq1.v {RTL_FOLDER}/pe_tile_new_unq1.v {RTL_FOLDER}/pe_tile_new_unq2.v {RTL_FOLDER}/sb_unq1.v {RTL_FOLDER}/sb_unq2.v {RTL_FOLDER}/sb_unq3.v  {RTL_FOLDER}/test_cmpr.sv {RTL_FOLDER}/test_full_add.sv {RTL_FOLDER}/test_lut.sv {RTL_FOLDER}/test_mult_add.sv {RTL_FOLDER}/test_opt_reg.sv {RTL_FOLDER}/test_pe_comp_unq1.sv {RTL_FOLDER}/test_pe_unq1.sv {RTL_FOLDER}/test_shifter_unq1.sv {RTL_FOLDER}/top.v
     result = delegator.run(f"""
-irun -top tb -timescale 1ns/1ps -l irun.log -access +rwc -notimingchecks -input cmd.tcl tb.v /nobackup/nikhil3/arm_mems/arm/tsmc/cln40g/sram_sp_hsc_rvt_hvt_rvt/r10p2/sram_512w_16b/sram_512w_16b.v {RTL_FOLDER}/cb_unq1.v {RTL_FOLDER}/cb_unq2.v {RTL_FOLDER}/cb_unq3.v {RTL_FOLDER}/global_controller_unq1.v {RTL_FOLDER}/global_signal_tile_unq1.v {RTL_FOLDER}/io1bit_unq1.v {RTL_FOLDER}/io1bit_unq2.v {RTL_FOLDER}/io1bit_unq3.v {RTL_FOLDER}/io1bit_unq4.v {RTL_FOLDER}/jtag_unq1.sv {RTL_FOLDER}/memory_core_unq1.v {RTL_FOLDER}/memory_tile_unq1.v {RTL_FOLDER}/mem_unq1.v {RTL_FOLDER}/pe_tile_new_unq1.v {RTL_FOLDER}/pe_tile_new_unq2.v {RTL_FOLDER}/sb_unq1.v {RTL_FOLDER}/sb_unq2.v {RTL_FOLDER}/sb_unq3.v  {RTL_FOLDER}/test_cmpr.sv {RTL_FOLDER}/test_full_add.sv {RTL_FOLDER}/test_lut.sv {RTL_FOLDER}/test_mult_add.sv {RTL_FOLDER}/test_opt_reg.sv {RTL_FOLDER}/test_pe_comp_unq1.sv {RTL_FOLDER}/test_pe_unq1.sv {RTL_FOLDER}/test_shifter_unq1.sv {RTL_FOLDER}/top.v
+irun -top test_pe_comp_unq1_tb -timescale 1ns/1ps -l irun.log -access +rwc -notimingchecks -input ../../hardware/generator_z/impl/verif/cmd.tcl build/ncsim_test_abs_complete_tb.v /nobackup/nikhil3/arm_mems/arm/tsmc/cln40g/sram_sp_hsc_rvt_hvt_rvt/r10p2/sram_512w_16b/sram_512w_16b.v {RTL_FOLDER}/cb_unq1.v {RTL_FOLDER}/cb_unq2.v {RTL_FOLDER}/cb_unq3.v {RTL_FOLDER}/global_signal_tile_unq1.v {RTL_FOLDER}/io1bit_unq1.v {RTL_FOLDER}/io1bit_unq2.v {RTL_FOLDER}/io1bit_unq3.v {RTL_FOLDER}/io1bit_unq4.v {RTL_FOLDER}/jtag_unq1.sv {RTL_FOLDER}/memory_core_unq1.v {RTL_FOLDER}/memory_tile_unq1.v {RTL_FOLDER}/mem_unq1.v {RTL_FOLDER}/pe_tile_new_unq1.v {RTL_FOLDER}/sb_unq1.v {RTL_FOLDER}/sb_unq2.v {RTL_FOLDER}/sb_unq3.v  {RTL_FOLDER}/test_cmpr.sv {RTL_FOLDER}/test_full_add.sv {RTL_FOLDER}/test_lut.sv {RTL_FOLDER}/test_mult_add.sv {RTL_FOLDER}/test_opt_reg.sv {RTL_FOLDER}/test_pe_comp_unq1.sv {RTL_FOLDER}/test_pe_unq1.sv {RTL_FOLDER}/test_shifter_unq1.sv {RTL_FOLDER}/top.v
     """)
     assert not result.return_code, result.out + "\n" + result.err
+    assert "Failed!" not in result.out, result.out + "\n" + result.err
 
 def test_and():
     a = and_()

--- a/tests/test_pe/test_pe.py
+++ b/tests/test_pe/test_pe.py
@@ -1,7 +1,8 @@
-import subprocess
 from pe import abs, and_
 from testvectors import complete
 from verilator import compile, run_verilator_test
+import ncsim
+import delegator
 
 def test_abs():
     a = abs()
@@ -10,6 +11,13 @@ def test_abs():
 
     compile('test_abs_complete', 'test_pe_comp_unq1', a.opcode, tests)
     run_verilator_test('test_pe_comp_unq1', 'sim_test_abs_complete', 'test_pe_comp_unq1')
+    print("== Compiling ncsim test bench ==")
+    ncsim.compile('test_abs_complete', a.opcode, tests)
+    RTL_FOLDER = "../../hardware/generator_z/top/genesis_verif"
+    result = delegator.run(f"""
+irun -top tb -timescale 1ns/1ps -l irun.log -access +rwc -notimingchecks -input cmd.tcl tb.v /nobackup/nikhil3/arm_mems/arm/tsmc/cln40g/sram_sp_hsc_rvt_hvt_rvt/r10p2/sram_512w_16b/sram_512w_16b.v {RTL_FOLDER}/cb_unq1.v {RTL_FOLDER}/cb_unq2.v {RTL_FOLDER}/cb_unq3.v {RTL_FOLDER}/global_controller_unq1.v {RTL_FOLDER}/global_signal_tile_unq1.v {RTL_FOLDER}/io1bit_unq1.v {RTL_FOLDER}/io1bit_unq2.v {RTL_FOLDER}/io1bit_unq3.v {RTL_FOLDER}/io1bit_unq4.v {RTL_FOLDER}/jtag_unq1.sv {RTL_FOLDER}/memory_core_unq1.v {RTL_FOLDER}/memory_tile_unq1.v {RTL_FOLDER}/mem_unq1.v {RTL_FOLDER}/pe_tile_new_unq1.v {RTL_FOLDER}/pe_tile_new_unq2.v {RTL_FOLDER}/sb_unq1.v {RTL_FOLDER}/sb_unq2.v {RTL_FOLDER}/sb_unq3.v  {RTL_FOLDER}/test_cmpr.sv {RTL_FOLDER}/test_full_add.sv {RTL_FOLDER}/test_lut.sv {RTL_FOLDER}/test_mult_add.sv {RTL_FOLDER}/test_opt_reg.sv {RTL_FOLDER}/test_pe_comp_unq1.sv {RTL_FOLDER}/test_pe_unq1.sv {RTL_FOLDER}/test_shifter_unq1.sv {RTL_FOLDER}/top.v
+    """)
+    assert not result.return_code, result.out + "\n" + result.err
 
 def test_and():
     a = and_()


### PR DESCRIPTION
This adds basic support for ncsim for the new unit tests. It basically replicates the verilator test harness. Here's the output harness for the `abs` test:
```verilog
`timescale 1ns/1ns
module test_pe_comp_unq1_tb;
localparam WIDTH = 16;
reg [WIDTH-1:0] op_a;
reg [WIDTH-1:0] op_b;
wire [WIDTH-1:0] res;

initial begin
  op_a = 0;
  op_b = 0;
  #1
  if (res != 0) $display("Failed!");
  #20
  op_a = 0;
  op_b = 1;
  #1
  if (res != 0) $display("Failed!");
  #20
  op_a = 0;
  op_b = 2;
  #1
  if (res != 0) $display("Failed!");
  #20
  op_a = 0;
  op_b = 3;
  #1
  if (res != 0) $display("Failed!");
  #20
  op_a = 1;
  op_b = 0;
  #1
  if (res != 1) $display("Failed!");
  #20
  op_a = 1;
  op_b = 1;
  #1
  if (res != 1) $display("Failed!");
  #20
  op_a = 1;
  op_b = 2;
  #1
  if (res != 1) $display("Failed!");
  #20
  op_a = 1;
  op_b = 3;
  #1
  if (res != 1) $display("Failed!");
  #20
  op_a = 2;
  op_b = 0;
  #1
  if (res != 2) $display("Failed!");
  #20
  op_a = 2;
  op_b = 1;
  #1
  if (res != 2) $display("Failed!");
  #20
  op_a = 2;
  op_b = 2;
  #1
  if (res != 2) $display("Failed!");
  #20
  op_a = 2;
  op_b = 3;
  #1
  if (res != 2) $display("Failed!");
  #20
  op_a = 3;
  op_b = 0;
  #1
  if (res != 3) $display("Failed!");
  #20
  op_a = 3;
  op_b = 1;
  #1
  if (res != 3) $display("Failed!");
  #20
  op_a = 3;
  op_b = 2;
  #1
  if (res != 3) $display("Failed!");
  #20
  op_a = 3;
  op_b = 3;
  #1
  if (res != 3) $display("Failed!");
  #20

  #20 $finish;
end


test_pe_comp_unq1 dut (
    .op_a(op_a),
    .op_b(op_b),
    .res(res),
    .op_code(3)
   );
endmodule
```

There's definitely improvements to be made, particularly for the test failure reporting, but this is the basic scaffolding that I figured we could merge in early.