### PR TITLE
Removed useless variable from lut

### DIFF
--- a/hardware/generator_z/pe_new/pe/rtl/test_lut.svp
+++ b/hardware/generator_z/pe_new/pe/rtl/test_lut.svp
@@ -52,10 +52,6 @@ generate
   end
 endgenerate
 
-
-logic [31:0] nc_cfg_d;
-assign nc_cfg_d = cfg_d;
-
 endmodule
 
 


### PR DESCRIPTION
@steveri I've been looking over the lookup table and this variable seems to be pointless.

Decided to remove it just for cleanup