### PR TITLE
Remove analog regs

### DIFF
--- a/hardware/generator_z/global_controller/global_controller.svp
+++ b/hardware/generator_z/global_controller/global_controller.svp
@@ -5,11 +5,8 @@
 //; my $jtag_obj = generate("jtag", "jtag_controller", SYSCLK_CFG_BUS_WIDTH => $cfg_bus_width, SYSCLK_CFG_ADDR_WIDTH => $cfg_addr_width, SYSCLK_CFG_OPCODE_WIDTH =>$cfg_op_width);
 //; my $jtag_ifc_path = $self -> define_param(IFC => $jtag_obj -> get_param('IFC'));
 //; my $jtag_ifc = clone($jtag_ifc_path, 'jtag_ifc');
-//; my $num_analog_regs = parameter(Name => 'num_analog_regs', val => 15, Doc => "Number of analog registers and analog_regfile");
 module `mname` (
 clk_in, reset_in,
-//; for (my $i = 0; $i < $num_analog_regs; $i++){
-analog_r`$i`,
 //; }
 config_data_in,
 config_addr_out,
@@ -24,8 +21,6 @@ tdo,
 tms,
 tck,
 trst_n,
-//FROM ANALOG
-jm_out
 );
   
   input  tck;
@@ -46,11 +41,6 @@ jm_out
   output reg [3:0] cgra_stalled;
   output tdo;
   
-  //value of each register in analog regfile
-//; for (my $i = 0; $i < $num_analog_regs; $i++){
-  output [`$cfg_bus_width-1`:0]  analog_r`$i`;
-//; }
-	
 
   wire [`$cfg_addr_width-1`:0] config_addr_jtag_out;
   wire [`$cfg_bus_width-1`:0] config_data_jtag_out;
@@ -59,9 +49,11 @@ jm_out
   reg clk;
   reg clk_domain;
   reg sys_clk_activated;
+
   //Extra flops to cross clock boundary
   reg sys_clk_act_sync_1;
   reg sys_clk_act_sync_2;
+
   //separate op out from address field
 `$jtag_obj -> instantiate` (.ifc_trst_n(trst_n),
 			    .ifc_tck(tck),
@@ -86,50 +78,25 @@ jm_out
 			    );
 
 
-// Internal signals to/from analog registers
-reg analog_wr_en; 
-reg [`$cfg_addr_width-1`:0] analog_data_in;
-reg [`$cfg_addr_width-1`:0] analog_addr;
-// instantiate registers for analog stuff
-//; my $analog_regfile = generate_base("analog_regfile","analog_regfile", num_regs => $num_analog_regs);
- `$analog_regfile -> instantiate()` (
-	.wr_en(analog_wr_en),
-	.data_in(analog_data_in),
-	.addr(analog_addr),
-//; for(my $i = 0; $i < $analog_regfile -> get_param('num_regs'); $i++) {
-	.r`$i`(analog_r`$i`),
-//; }	
-	.jm_out(jm_out),
-	.clk(clk),
-	.reset(reset_out)
-	);
 
   //OPCODES
   parameter NOP = `$cfg_op_width`'d0;
   parameter write_config =`$cfg_op_width`'d1;
   parameter read_config = `$cfg_op_width`'d2;
-  //parameter set_base_reg = `$cfg_op_width`'d3;
-  //parameter set_rw_and_count = `$cfg_op_width`'d4;
-  //parameter burst_start = `$cfg_op_width`'d5;
-  //parameter write_data = `$cfg_op_width`'d5;
-  //parameter read_data = `$cfg_op_width`'d6;
-  parameter write_A050 = `$cfg_op_width`'d7;
-  parameter write_TST = `$cfg_op_width`'d8;
-  parameter read_TST = `$cfg_op_width`'d9;
-  parameter global_reset = `$cfg_op_width`'d10;
-  //parameter reset_tile = `$cfg_op_width`'d11; 
-  parameter write_stall = `$cfg_op_width`'d11;
-  parameter read_stall = `$cfg_op_width`'d12;
-  parameter advance_clk = `$cfg_op_width`'d13;
-  //parameter resume_clk = `$cfg_op_width`'d14;
-  parameter read_clk_domain = `$cfg_op_width`'d14;
-  parameter switch_clk = `$cfg_op_width`'d15;
-  parameter wr_rd_delay_reg = `$cfg_op_width`'d16;
-  parameter rd_rd_delay_reg = `$cfg_op_width`'d17;
-  parameter wr_delay_sel_reg = `$cfg_op_width`'d18;
-  parameter rd_delay_sel_reg = `$cfg_op_width`'d19;
-  parameter wr_analog_reg = `$cfg_op_width`'d20;
-  parameter rd_analog_reg = `$cfg_op_width`'d21;
+  parameter write_A050 = `$cfg_op_width`'d3;
+  parameter write_TST = `$cfg_op_width`'d4;
+  parameter read_TST = `$cfg_op_width`'d5;
+  parameter global_reset = `$cfg_op_width`'d6;
+  parameter write_stall = `$cfg_op_width`'d7;
+  parameter read_stall = `$cfg_op_width`'d8;
+  parameter advance_clk = `$cfg_op_width`'d9;
+  parameter read_clk_domain = `$cfg_op_width`'d10;
+  parameter switch_clk = `$cfg_op_width`'d11;
+  parameter wr_rd_delay_reg = `$cfg_op_width`'d12;
+  parameter rd_rd_delay_reg = `$cfg_op_width`'d13;
+  parameter wr_delay_sel_reg = `$cfg_op_width`'d14;
+  parameter rd_delay_sel_reg = `$cfg_op_width`'d15;
+  
   //STATES FOR IGNORING INCOMING INSTRUCTIONS
   parameter ready = 3'd0;
   parameter reading = 3'd1;
@@ -137,7 +104,8 @@ reg [`$cfg_addr_width-1`:0] analog_addr;
   parameter advancing_clk = 3'd3;
   parameter switching_clk = 3'd4;
   reg [2:0] state;
-  //USED to remember old stall signal when advancing clk
+  
+  //This value is to remember old stall signal when advancing clk
   reg [3:0] stall_restore;
  
   logic all_stalled_tck;
@@ -272,9 +240,6 @@ reg [`$cfg_addr_width-1`:0] analog_addr;
 		delay_sel <= 2'b0;
 		read <= 0;
 		write <= 0;
-		analog_wr_en <= 0;
-		analog_data_in <= 0;
-		analog_addr <= 0;
 		state <= ready;
     	end
 
@@ -287,14 +252,12 @@ reg [`$cfg_addr_width-1`:0] analog_addr;
 				config_data_jtag_in <= config_data_jtag_in;	
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 			end
 			write_config: begin
 				config_addr_out <= config_addr_jtag_out;
 				config_data_out <= config_data_jtag_out; 
 				read <= 0;
 				write <= 1;
-				analog_wr_en <= 0;
 			end
 			read_config: begin
 				config_addr_out <= config_addr_jtag_out;
@@ -303,44 +266,37 @@ reg [`$cfg_addr_width-1`:0] analog_addr;
 				state <= reading;
 				read <= 1;
 				write <= 0;
-				analog_wr_en <= 0;
 			end
 			write_A050: begin
 				config_data_jtag_in <= `$cfg_bus_width`'hA050;
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 			end
 			write_TST: begin
 				TST <= config_data_jtag_out;
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 			end
 			read_TST: begin
 				config_data_jtag_in <= TST;
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 			end
 			global_reset: begin
 				state <= resetting;
 				counter <= (config_data_jtag_out > 0) ? config_data_jtag_out-1 : `$cfg_bus_width`'d19;
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 			end
 			read_stall: begin
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 				config_data_jtag_in <= {`$cfg_bus_width-4`'b0, cgra_stalled};
 			end
 			write_stall: begin
 				cgra_stalled <= config_data_jtag_out[3:0];
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 			end			
 			advance_clk: begin
 				if (config_data_jtag_out > 0) begin
@@ -355,12 +311,10 @@ reg [`$cfg_addr_width-1`:0] analog_addr;
 				end
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 			end
 			read_clk_domain: begin
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 				config_data_jtag_in <= {31'b0, sys_clk_activated};
 			end
 			switch_clk: begin
@@ -371,48 +325,25 @@ reg [`$cfg_addr_width-1`:0] analog_addr;
 				end
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 			end
 			wr_rd_delay_reg: begin
 				//Prevent underflow by setting this to 1 if the input data is 0.
 				rd_delay_reg <= (config_data_jtag_out > 0) ? config_data_jtag_out : 1;
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 			end
 			rd_rd_delay_reg: begin
 				config_data_jtag_in <= rd_delay_reg;
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 			end
 			wr_delay_sel_reg: begin
 				delay_sel <= config_data_jtag_out[1:0];
 				read <= 0;
 				write <= 0;
-				analog_wr_en <= 0;
 			end
 			rd_delay_sel_reg: begin
 				config_data_jtag_in <= {`$cfg_bus_width-2`'b0,delay_sel};
-				read <= 0;
-				write <= 0;
-				analog_wr_en <= 0;
-			end
-			wr_analog_reg: begin
-				analog_wr_en <= 1;
-				analog_data_in <= config_data_jtag_out;
-				analog_addr <= config_addr_jtag_out;
-				read <= 0;
-				write <= 0;	
-			end
-			rd_analog_reg: begin	
-				case(config_addr_jtag_out)
-//; 	for(my $i = 0; $i < $analog_regfile -> get_param('num_regs'); $i++) {
-					'd`$i`: config_data_jtag_in <= analog_r`$i`;
-//;	}	
-					default: config_data_jtag_in <= 0;
-				endcase
-				analog_wr_en <= 0;
 				read <= 0;
 				write <= 0;
 			end

--- a/hardware/generator_z/global_controller/global_controller.svp
+++ b/hardware/generator_z/global_controller/global_controller.svp
@@ -7,7 +7,6 @@
 //; my $jtag_ifc = clone($jtag_ifc_path, 'jtag_ifc');
 module `mname` (
 clk_in, reset_in,
-//; }
 config_data_in,
 config_addr_out,
 config_data_out,

--- a/hardware/generator_z/global_controller/global_controller.svp
+++ b/hardware/generator_z/global_controller/global_controller.svp
@@ -28,7 +28,6 @@ trst_n,
   input  tdi;
   input  tms;
   input  trst_n;
-  input [19:0] jm_out;
   input [`$cfg_bus_width-1`:0] config_data_in;
 
   output reg read;

--- a/hardware/generator_z/global_controller/global_controller.svp
+++ b/hardware/generator_z/global_controller/global_controller.svp
@@ -83,19 +83,19 @@ trst_n,
   parameter NOP = `$cfg_op_width`'d0;
   parameter write_config =`$cfg_op_width`'d1;
   parameter read_config = `$cfg_op_width`'d2;
-  parameter write_A050 = `$cfg_op_width`'d3;
-  parameter write_TST = `$cfg_op_width`'d4;
-  parameter read_TST = `$cfg_op_width`'d5;
-  parameter global_reset = `$cfg_op_width`'d6;
-  parameter write_stall = `$cfg_op_width`'d7;
-  parameter read_stall = `$cfg_op_width`'d8;
-  parameter advance_clk = `$cfg_op_width`'d9;
-  parameter read_clk_domain = `$cfg_op_width`'d10;
-  parameter switch_clk = `$cfg_op_width`'d11;
-  parameter wr_rd_delay_reg = `$cfg_op_width`'d12;
-  parameter rd_rd_delay_reg = `$cfg_op_width`'d13;
-  parameter wr_delay_sel_reg = `$cfg_op_width`'d14;
-  parameter rd_delay_sel_reg = `$cfg_op_width`'d15;
+  parameter write_A050 = `$cfg_op_width`'d4;
+  parameter write_TST = `$cfg_op_width`'d5;
+  parameter read_TST = `$cfg_op_width`'d6;
+  parameter global_reset = `$cfg_op_width`'d7;
+  parameter write_stall = `$cfg_op_width`'d8;
+  parameter read_stall = `$cfg_op_width`'d9;
+  parameter advance_clk = `$cfg_op_width`'d10;
+  parameter read_clk_domain = `$cfg_op_width`'d11;
+  parameter switch_clk = `$cfg_op_width`'d12;
+  parameter wr_rd_delay_reg = `$cfg_op_width`'d13;
+  parameter rd_rd_delay_reg = `$cfg_op_width`'d14;
+  parameter wr_delay_sel_reg = `$cfg_op_width`'d15;
+  parameter rd_delay_sel_reg = `$cfg_op_width`'d16;
   
   //STATES FOR IGNORING INCOMING INSTRUCTIONS
   parameter ready = 3'd0;

--- a/hardware/generator_z/global_controller/global_controller.svp
+++ b/hardware/generator_z/global_controller/global_controller.svp
@@ -19,7 +19,7 @@ tdi,
 tdo,
 tms,
 tck,
-trst_n,
+trst_n
 );
   
   input  tck;

--- a/hardware/generator_z/global_controller/verif/JTAGDriver.svp
+++ b/hardware/generator_z/global_controller/verif/JTAGDriver.svp
@@ -239,8 +239,8 @@ endclass: `mname`
       
       if (this.svf_file)
 	$fdisplay(this.svf_file, "RUNTEST IDLE 10 TCK IDLE;\n");
-      //Next_tck();
-      //Next_tck();
+      Next_tck();
+      Next_tck();
       cur_trans.done = 1;
    endtask // Send
 

--- a/hardware/generator_z/global_controller/verif/JTAGDriver.svp
+++ b/hardware/generator_z/global_controller/verif/JTAGDriver.svp
@@ -72,7 +72,7 @@ parameter max_bus_width = max_int(max_int(sc_bus_width, tc_bus_width), 32);
 parameter max_addr_width = max_int(sc_addr_width, tc_addr_width);
 
 typedef enum {sc_domain, tc_domain} regfile_t;
-typedef enum logic [max_int(tc_op_width, sc_op_width)-1:0] {nop=0, write=1, read=2, wr_A050=7, wr_TST=8, rd_TST=9, global_reset=10, write_stall=11, read_stall=12, advance_clk=13, read_clk_domain=14, switch_clk=15, wr_rd_delay_reg=16, rd_rd_delay_reg=17,wr_delay_sel_reg=18,rd_delay_sel_reg=19,wr_analog_reg=20,rd_analog_reg=21} regfile_op_t;
+typedef enum logic [max_int(tc_op_width, sc_op_width)-1:0] {nop=0, write=1, read=2, wr_A050=4, wr_TST=5, rd_TST=6, global_reset=7, write_stall=8, read_stall=9, advance_clk=10, read_clk_domain=11, switch_clk=12, wr_rd_delay_reg=13, rd_rd_delay_reg=14,wr_delay_sel_reg=15,rd_delay_sel_reg=16} regfile_op_t;
 
 typedef struct {
    logic [max_bus_width-1:0] data_in;
@@ -183,7 +183,7 @@ endclass: `mname`
 
 	 // read or write changes the order of data vs op
 	 // for reads, first send instructions then get data
-	 if (cur_trans.op == read | cur_trans.op == rd_TST | cur_trans.op == rd_rd_delay_reg | cur_trans.op == rd_delay_sel_reg | cur_trans.op == wr_A050 | cur_trans.op == read_stall | cur_trans.op == read_clk_domain | cur_trans.op == rd_analog_reg) begin
+	 if (cur_trans.op == read | cur_trans.op == rd_TST | cur_trans.op == rd_rd_delay_reg | cur_trans.op == rd_delay_sel_reg | cur_trans.op == wr_A050 | cur_trans.op == read_stall | cur_trans.op == read_clk_domain) begin
 	    // send instruction
 	    ShiftIR(sc_cfg_inst, jtag_inst_width);
 	    ShiftDR(cur_trans.op, sc_op_width);

--- a/hardware/generator_z/global_controller/verif/run.csh
+++ b/hardware/generator_z/global_controller/verif/run.csh
@@ -4,7 +4,6 @@ Genesis2.pl -parse -generate -top top -input 		top.svp \
 							clocker.svp \
 							test.svp \
 							../global_controller.svp \
-							../analog_regfile.vp \
 							../../jtag/jtag.svp \
 						        ../../jtag/Template/src/digital/template_ifc.svp \
 							../../jtag/Template/src/digital/cfg_ifc.svp \

--- a/hardware/generator_z/global_controller/verif/run_sim.csh
+++ b/hardware/generator_z/global_controller/verif/run_sim.csh
@@ -5,7 +5,6 @@ irun -top top -timescale 1ns/1ps -l irun.log -access +rwc -notimingchecks -input
 cmd.tcl \
 $RTL_FOLDER/top.sv \
 $RTL_FOLDER/cfg_and_dbg_unq1.sv \
-$RTL_FOLDER/analog_regfile.v \
 $RTL_FOLDER/cfg_ifc_unq1.sv \
 $RTL_FOLDER/clocker_unq1.sv \
 $RTL_FOLDER/flop_unq1.sv \

--- a/hardware/generator_z/global_controller/verif/test.svp
+++ b/hardware/generator_z/global_controller/verif/test.svp
@@ -255,7 +255,7 @@ program automatic `mname`(interface ifc);
    task switch_clk(int data_in);
      begin
         jtag_trans.op = switch_clk;
-        jtag_trans.data_in = 1;
+        jtag_trans.data_in = data_in;
         jtag_trans.done = 0;
         jdrv.Send(jtag_trans);
         config_count++;

--- a/hardware/generator_z/global_controller/verif/top.svp
+++ b/hardware/generator_z/global_controller/verif/top.svp
@@ -70,7 +70,7 @@ module `mname`();
    //; my $dut_ifc = clone($dut_ifc_path, 'dut_ifc');
    `$dut_ifc->instantiate` (.Clk(Clk), .Reset(Reset));
    
-   `$dut_obj->instantiate` (.jm_out(19'd220)); //.ifc(`$dut_ifc->iname()`));
+   `$dut_obj->instantiate` (); //.ifc(`$dut_ifc->iname()`));
    //Since we aren't using interface here, assign singals 
    //Inputs
    assign dut.tck = dut_ifc.tck;

--- a/hardware/generator_z/jtag/jtag.svp
+++ b/hardware/generator_z/jtag/jtag.svp
@@ -166,12 +166,12 @@ module `$self->get_module_name()`
    //;					SC_CFG_BUS => 'yes', 
    //;					TC_CFG_BUS => 'no', SC_CFG_IFC_REF => $sc_jtag2gc_ifc,
    //;					SC_CFG_OPCODES => {nop => 0, write => 1, read => 2, bypass => 3,                                                 
-   //;                                                 wr_A050 => 7, wr_to_TST => 8, rd_TST => 9,
-   //; 						       global_reset => 10, write_stall => 11,read_stall => 12, 
-   //;    					       adv_clk => 13, read_clk_domain => 14, switch_clk => 15,
-   //;						       wr_rd_delay_reg => 16, rd_rd_delay_reg => 17, wr_delay_sel_reg => 18,
-   //;						       rd_delay_sel_reg => 19, wr_analog_reg => 20, rd_analog_reg => 21} 
-   //;					);#Should this really be bypass??
+   //;                                                 wr_A050 => 4, wr_to_TST => 5, rd_TST => 6,
+   //; 						       global_reset => 7, write_stall => 8,read_stall => 9, 
+   //;    					       adv_clk => 10, read_clk_domain => 11, switch_clk => 12,
+   //;						       wr_rd_delay_reg => 13, rd_rd_delay_reg => 14, wr_delay_sel_reg => 15,
+   //;						       rd_delay_sel_reg => 16} 
+   //;					);
    //;
    
    //These signals aren't used. Only included to avoid warnings.			

--- a/hardware/generator_z/top/build_cgra.sh
+++ b/hardware/generator_z/top/build_cgra.sh
@@ -85,7 +85,6 @@ Genesis2.pl -parse -generate -top top -hierarchy top.xml -input\
   ../memory_core/memory_core.vp \
   \
   ../global_controller/global_controller.svp \
-  ../global_controller/analog_regfile.vp \
   \
   ../jtag/jtag.svp \
   ../jtag/Template/src/digital/template_ifc.svp \

--- a/hardware/generator_z/top/build_cgra.sh
+++ b/hardware/generator_z/top/build_cgra.sh
@@ -106,9 +106,9 @@ echo HACKWARNING Using custom stub instead of proprietary DW_tap
 echo HACKWARNING Using custom stub instead of proprietary DW_tap
 echo HACKWARNING Using custom stub instead of proprietary DW_tap
 echo cp  ../jtag/Template/src/digital/DW_tap.v.stub genesis_verif/DW_tap.v
-echo cp  mdll_top.sv genesis_verif/mdll_top.sv
+#echo cp  mdll_top.sv genesis_verif/mdll_top.sv
 cp  ../jtag/Template/src/digital/DW_tap.v.stub genesis_verif/DW_tap.v
-cp mdll_top.sv genesis_verif/mdll_top.sv
+#cp mdll_top.sv genesis_verif/mdll_top.sv
 ls -l ../jtag/Template/src/digital/DW_tap.v.stub
 ls -l genesis_verif/DW_tap.v
 echo

--- a/hardware/generator_z/top/build_cgra.sh
+++ b/hardware/generator_z/top/build_cgra.sh
@@ -106,9 +106,9 @@ echo HACKWARNING Using custom stub instead of proprietary DW_tap
 echo HACKWARNING Using custom stub instead of proprietary DW_tap
 echo HACKWARNING Using custom stub instead of proprietary DW_tap
 echo cp  ../jtag/Template/src/digital/DW_tap.v.stub genesis_verif/DW_tap.v
-#echo cp  mdll_top.sv genesis_verif/mdll_top.sv
+echo cp  mdll_top.sv genesis_verif/mdll_top.sv
 cp  ../jtag/Template/src/digital/DW_tap.v.stub genesis_verif/DW_tap.v
-#cp mdll_top.sv genesis_verif/mdll_top.sv
+cp mdll_top.sv genesis_verif/mdll_top.sv
 ls -l ../jtag/Template/src/digital/DW_tap.v.stub
 ls -l genesis_verif/DW_tap.v
 echo

--- a/hardware/generator_z/top/top.vp
+++ b/hardware/generator_z/top/top.vp
@@ -5,6 +5,7 @@
 //; use POSIX;
 //; #### CHANGE THIS TO 1 TO CONNECT ALL GC SIGNALS FOR TAPEOUT @NIKHIL
 //; my $connect_GC = parameter(NAME => 'connect_GC', val => 0, Min => 0, Max => 1, Step => 1); 
+//; my $include_analog_block = parameter(NAME => 'include_analog_block', val => 0, Min => 0, Max => 1, Step => 1);
 //; #########################################
 //; #// Generator Configuration Start 
 //; ######################################### 
@@ -445,9 +446,6 @@ wire [31:0] read_data_memory;
 wire [31:0] read_data_io1bit;
 wire [3:0] stall;
 //; my $global_controller_obj = generate("global_controller", "global_controller");
-//; for (my $i = 0; $i < $global_controller_obj->get_param('num_analog_regs'); $i++){
-wire [31:0] analog_r`$i`;
-//; }
 //; my $jtag_ifc_path = parameter(NAME => 'IFC', VAL => $global_controller_obj -> get_param('IFC'), DOC => "Path to JTAG interface for JTAGDriver");
     `$global_controller_obj->instantiate()` 
     (
@@ -466,12 +464,8 @@ wire [31:0] analog_r`$i`;
       .tms(tms),
       .tck(tck),
       .trst_n(trst_n),
-//; for (my $i = 0; $i < $global_controller_obj->get_param('num_analog_regs'); $i++){
-      .analog_r`$i`(analog_r`$i`),
-//; }
       .cgra_stalled(stall),
       .read(config_read),
-      .jm_out(jm_out)
     );
 //; if($connect_GC == 0) {
     //UNTIL WE FIX TESTS TO INPUT CFG ADDR AND DATA THROUGH JTAG, DON'T RUN CLK SIGNALS THROUGH GC
@@ -481,6 +475,8 @@ wire [31:0] analog_r`$i`;
     assign reset = reset_in;
     assign config_write = 1;
 //; }
+//; if ($include_analog_block) {
+  //Instantiate analog block
   mdll_top mdll_top 
   (
     .ext_cki(ext_cki),  // (+) cmos clock   . (reference clock   .)
@@ -558,6 +554,7 @@ wire [31:0] analog_r`$i`;
     .lf_out(lf_out)    // LF output (MSB 7bits for mtune, LSB 6bits for dithering)
   );
 //INSTANTIATE ANALOG BLOCK
+//; } #if ($include_analog_block)
 
 
 // FIXME Note there are LOTS of unused wires being created below!

--- a/hardware/generator_z/top/top.vp
+++ b/hardware/generator_z/top/top.vp
@@ -465,7 +465,7 @@ wire [3:0] stall;
       .tck(tck),
       .trst_n(trst_n),
       .cgra_stalled(stall),
-      .read(config_read),
+      .read(config_read)
     );
 //; if($connect_GC == 0) {
     //UNTIL WE FIX TESTS TO INPUT CFG ADDR AND DATA THROUGH JTAG, DON'T RUN CLK SIGNALS THROUGH GC


### PR DESCRIPTION
Primarily, this removes the analog register file from the global controller, as discussed in the meeting. Going forward, we will require the analog blocks to contain their own configuration registers, and we will simply provide them with the global controller interface.

I also added a parameter at the top level that controls whether or not the analog block (mdll_top) should be included in the CGRA. This parameter defaults to 0, which means that the analog is left out by default.