### PR TITLE
Add run.csh for io1bit and fix incorrect blocking assignments

### DIFF
--- a/hardware/generator_z/io1bit/io1bit.vp
+++ b/hardware/generator_z/io1bit/io1bit.vp
@@ -58,12 +58,12 @@ read_data
   reg out_bus;
   always @(posedge clk or posedge reset) begin
     if (reset==1'b1) begin
-       io_bit = 1'b0;
-       out_bus = 1'b0;
+       io_bit <= 1'b0;
+       out_bus <= 1'b0;
     end else begin
        if (config_en==1'b1) begin
-         io_bit = config_data[0];
-         out_bus = config_data[1];
+         io_bit <= config_data[0];
+         out_bus <= config_data[1];
        end
     end
   end

--- a/hardware/generator_z/io1bit/run.csh
+++ b/hardware/generator_z/io1bit/run.csh
@@ -1,0 +1,1 @@
+Genesis2.pl -parse -generate -top io1bit -input io1bit.vp -parameter io1bit.io_group=0


### PR DESCRIPTION
Small PR that adds a script to run genesis for the io1bit tile and fixes some blocking assignments in an always @ (posedge clk) block