### PR TITLE
Connect enable_chain to correct bit of config_mem

### DIFF
--- a/hardware/generator_z/memory_core/memory_core.vp
+++ b/hardware/generator_z/memory_core/memory_core.vp
@@ -124,7 +124,7 @@ assign mode = config_mem[1:0];
 assign tile_en = config_mem[2];
 assign depth = config_mem[15:3];
 assign almost_count = config_mem[19:16];
-assign enable_chain = config_mem[19];
+assign enable_chain = config_mem[20];
 assign gclk_in = (tile_en==1'b1) ? clk_in : 0;
 assign gclk = clk_en ? gclk_in : 0;
 assign gclk_sram = (clk_en || config_en_sram) ? gclk_in : 0;


### PR DESCRIPTION
Quick one-line PR. This is the bug Raj and I pointed out in the Garnet presentation on Wednesday. You'll notice that both enable_chain and almost_count are connected to config_mem[19]. Also, if you look at where the collateral is printed at the bottom of the file, it says enable_chain should be connected to config_mem[20].